### PR TITLE
Update Lifecycle of table.md

### DIFF
--- a/intl.en-US/User Guide/SQL/DDL SQL/Lifecycle of table.md
+++ b/intl.en-US/User Guide/SQL/DDL SQL/Lifecycle of table.md
@@ -36,7 +36,7 @@ In some cases, the data in specified partitions do not need to be recycled by th
 **Statement format:**
 
 ```
-ALTER TABLE table_name [partition_spec] ENABLE|DISABLE LIFECYCLE;
+ALTER TABLE table_name [PARTITION partition_spec] ENABLE|DISABLE LIFECYCLE;
 ```
 
 An example is shown as follows.


### PR DESCRIPTION
Add PARTITION keyword to statement format for disabling lifecycle on a partition. This is for consistency with other docs such as https://www.alibabacloud.com/help/doc-detail/73771.htm?#title-1zx-4gs-6z8 that specify the partition_spec as the partition columns surrounded by parentheses. E.g.:

partition_spec:(partition_col1 = partition_col_value1, partition_col2 = partiton_col_value2, ...) ;